### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # jsreplproject
+[![Run on Repl.it](https://repl.it/badge/github/kpoitevien/jsreplproject)](https://repl.it/github/kpoitevien/jsreplproject)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@kiarapoitevien/jsreplproject).